### PR TITLE
Add orders queue

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -29,3 +29,4 @@ module cosmosDB 'modules/cosmos-db.bicep' = {
   }
 }
 
+// Update

--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -28,3 +28,4 @@ module cosmosDB 'modules/cosmos-db.bicep' = {
     cosmosDBAccountName: cosmosDBAccountName
   }
 }
+


### PR DESCRIPTION
This PR adds a new Azure Storage queue for processing orders, and updates the website configuration to include the storage account and queue information.